### PR TITLE
[#20] WIP Add abstraction layer to persistance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Code env specific
+.vscode
+*.egg

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -19,7 +19,7 @@ Jinja2==3.0.3
 jmespath==0.10.0
 MarkupSafe==2.0.1
 mccabe==0.6.1
-mypy==0.910
+mypy==0.960
 mypy-extensions==0.4.3
 numpy==1.21.2
 packaging==21.0
@@ -56,4 +56,4 @@ tomli==1.2.2
 types-retry==0.9.2
 typing-extensions==3.10.0.2
 urllib3==1.26.7
-wandb==0.12.11
+wandb==0.12.21

--- a/docs/source/getstarted.rst
+++ b/docs/source/getstarted.rst
@@ -83,7 +83,7 @@ Spark is a common data engine and Wicker provides integrations to write datasets
 
 .. code-block:: python3
 
-    from wicker.plugins.spark import persist_wicker_dataset
+    from wicker.plugins.spark import SparkPersistor
 
     examples = [
         (
@@ -96,7 +96,8 @@ Spark is a common data engine and Wicker provides integrations to write datasets
     ]
 
     rdd = spark_context.parallelize(examples)
-    persist_wicker_dataset(
+    persistor = SparkPersistor()
+    persistor.persist_wicker_dataset(
         "my_dataset_name",
         "0.0.1",
         MY_SCHEMA,

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,7 @@
+[mypy]
+python_version = 3.8
+warn_unused_configs = True
+
 [mypy-boto3.*]
 ignore_missing_imports = True
 

--- a/notebooks/Wicker Hello World.ipynb
+++ b/notebooks/Wicker Hello World.ipynb
@@ -167,7 +167,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from wicker.plugins.spark import persist_wicker_dataset\n",
+    "from wicker.plugins.spark import SparkPersistor\n",
     "from pyspark.sql import SparkSession\n",
     "import copy"
    ]
@@ -206,7 +206,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "persist_wicker_dataset(\n",
+    "persistor = SparkPersistor()\n",
+    "persistor.persist_wicker_dataset(\n",
     "    DATASET_NAME,\n",
     "    DATASET_VERSION,\n",
     "    DATASET_SCHEMA,\n",

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -71,13 +71,7 @@ class LocalWritingTestCase(unittest.TestCase):
             spark = spark_session.getOrCreate()
             sc = spark.sparkContext
             rdd = sc.parallelize(copy.deepcopy(EXAMPLES), 100)
-            persist_wicker_dataset(
-                DATASET_NAME,
-                DATASET_VERSION,
-                SCHEMA,
-                rdd,
-                s3_storage=fake_storage,
-            )
+            persist_wicker_dataset(DATASET_NAME, DATASET_VERSION, SCHEMA, rdd, fake_storage)
             self.assert_written_correctness(tmpdir)
 
     def test_dupe_primary_keys_raises_exception(self) -> None:
@@ -88,13 +82,7 @@ class LocalWritingTestCase(unittest.TestCase):
                 spark = spark_session.getOrCreate()
                 sc = spark.sparkContext
                 rdd = sc.parallelize(copy.deepcopy(EXAMPLES_DUPES), 100)
-                persist_wicker_dataset(
-                    DATASET_NAME,
-                    DATASET_VERSION,
-                    SCHEMA,
-                    rdd,
-                    s3_storage=fake_storage,
-                )
+                persist_wicker_dataset(DATASET_NAME, DATASET_VERSION, SCHEMA, rdd, fake_storage)
 
             self.assertIn(
                 "Error: dataset examples do not have unique primary key tuples",

--- a/wicker/core/persistance.py
+++ b/wicker/core/persistance.py
@@ -21,9 +21,6 @@ class AbstractDataPersistor(abc.ABC):
         self,
         s3_storage: S3DataStorage = S3DataStorage(),
         s3_path_factory: S3PathFactory = S3PathFactory(),
-        schema: Optional[schema.DatasetSchema] = None,
-        dataset_name: Optional[str] = None,
-        dataset_version: Optional[str] = None,
     ) -> None:
         """
         Init a Persister
@@ -33,22 +30,10 @@ class AbstractDataPersistor(abc.ABC):
         :param s3_path_factory: The path factory for generating s3 paths
                                 based on dataset name and version
         :type s3_path_factory: S3PathFactory
-        :param schema: Dataschema to be set initially, no setting makes
-            empty schema
-        :type schema: wicker.schema.schema.DatasetSchema or none
-        :param dataset_name: Name of the dataset to be set initially
-            empty sets to unassigned
-        :type dataset_name: str or none
-        :param dataset_version: Version of the dataset to be set intitially
-            empty sets to unassigned
-        :type current_dataset_version: str or none
         """
         super().__init__()
         self.s3_storage = s3_storage
         self.s3_path_factory = s3_path_factory
-        self._current_schema = schema
-        self._current_dataset_name = dataset_name
-        self._current_dataset_version = dataset_version
 
     @abc.abstractmethod
     def persist_wicker_dataset(
@@ -70,18 +55,7 @@ class AbstractDataPersistor(abc.ABC):
         :param dataset: Data of the dataset
         :type dataset: User defined
         """
-        raise NotImplementedError("Method, persist_wicker_dataset, needs to" "be implemented in inhertiance class.")
-
-    @abc.abstractmethod
-    def persist_current_wicker_dataset(
-        self,
-    ) -> Optional[Dict[str, int]]:
-        """
-        Persist the current dataset defined by name, version, schema, and data.
-        """
-        raise NotImplementedError(
-            "Method, persist_current_wicker_dataset, needs" "to be implemented in inheritance class"
-        )
+        raise NotImplementedError("Method, persist_wicker_dataset, needs to be implemented in inhertiance class.")
 
     @staticmethod
     def parse_row(data_row: UnparsedExample, schema: schema.DatasetSchema) -> ParsedExample:

--- a/wicker/core/persistance.py
+++ b/wicker/core/persistance.py
@@ -1,0 +1,96 @@
+import abc
+from typing import Any, Dict, Optional
+
+from wicker import schema
+from wicker.core.storage import S3DataStorage, S3PathFactory
+from wicker.schema import dataparsing
+
+UnparsedExample = Dict[str, Any]
+ParsedExample = Dict[str, Any]
+
+
+class AbstractDataPersistor(abc.ABC):
+    """
+    Abstract class for persisting data onto a user defined cloud or local instance.
+
+    Only s3 is supported right now but plan to support other data stores
+    (BigQuery, Whatever the hell Azure is called, Postgres)
+    """
+
+    def __init__(
+        self,
+        s3_storage: S3DataStorage = S3DataStorage(),
+        s3_path_factory: S3PathFactory = S3PathFactory(),
+        schema: Optional[schema.DatasetSchema] = None,
+        dataset_name: Optional[str] = None,
+        dataset_version: Optional[str] = None,
+    ) -> None:
+        """
+        Init a Persister
+
+        :param s3_storage: The storage abstraction for S3
+        :type s3_storage: S3DataStore
+        :param s3_path_factory: The path factory for generating s3 paths
+                                based on dataset name and version
+        :type s3_path_factory: S3PathFactory
+        :param schema: Dataschema to be set initially, no setting makes
+            empty schema
+        :type schema: wicker.schema.schema.DatasetSchema or none
+        :param dataset_name: Name of the dataset to be set initially
+            empty sets to unassigned
+        :type dataset_name: str or none
+        :param dataset_version: Version of the dataset to be set intitially
+            empty sets to unassigned
+        :type current_dataset_version: str or none
+        """
+        super().__init__()
+        self.s3_storage = s3_storage
+        self.s3_path_factory = s3_path_factory
+        self._current_schema = schema
+        self._current_dataset_name = dataset_name
+        self._current_dataset_version = dataset_version
+
+    @abc.abstractmethod
+    def persist_wicker_dataset(
+        self,
+        dataset_name: str,
+        dataset_version: str,
+        dataset_schema: schema.DatasetSchema,
+        dataset: Any,
+    ) -> Optional[Dict[str, int]]:
+        """
+        Persist a user specified dataset defined by name, version, schema, and data.
+
+        :param dataset_name: Name of the dataset
+        :type dataset_name: str
+        :param dataset_version: Version of the dataset
+        :type: dataset_version: str
+        :param dataset_schema: Schema of the dataset
+        :type dataset_schema: wicker.schema.schema.DatasetSchema
+        :param dataset: Data of the dataset
+        :type dataset: User defined
+        """
+        raise NotImplementedError("Method, persist_wicker_dataset, needs to" "be implemented in inhertiance class.")
+
+    @abc.abstractmethod
+    def persist_current_wicker_dataset(
+        self,
+    ) -> Optional[Dict[str, int]]:
+        """
+        Persist the current dataset defined by name, version, schema, and data.
+        """
+        raise NotImplementedError(
+            "Method, persist_current_wicker_dataset, needs" "to be implemented in inheritance class"
+        )
+
+    @staticmethod
+    def parse_row(data_row: UnparsedExample, schema: schema.DatasetSchema) -> ParsedExample:
+        """
+        Parse a row to test for validation errors.
+
+        :param data_row: Data row to be parsed
+        :type data_row: UnparsedExample
+        :return: parsed row containing the correct types associated with schema
+        :rtype: ParsedExample
+        """
+        return dataparsing.parse_example(data_row, schema)

--- a/wicker/core/persistance.py
+++ b/wicker/core/persistance.py
@@ -14,7 +14,7 @@ class AbstractDataPersistor(abc.ABC):
     Abstract class for persisting data onto a user defined cloud or local instance.
 
     Only s3 is supported right now but plan to support other data stores
-    (BigQuery, Whatever the hell Azure is called, Postgres)
+    (BigQuery, Azure, Postgres)
     """
 
     def __init__(

--- a/wicker/plugins/spark.py
+++ b/wicker/plugins/spark.py
@@ -7,7 +7,8 @@ for large datasets.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, Tuple
+import logging
+from typing import Any, Dict, Iterable, Optional, Tuple
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -26,9 +27,10 @@ from wicker import schema
 from wicker.core.column_files import ColumnBytesFileWriter
 from wicker.core.definitions import DatasetID
 from wicker.core.errors import WickerDatastoreException
+from wicker.core.persistance import AbstractDataPersistor
 from wicker.core.shuffle import save_index
 from wicker.core.storage import S3DataStorage, S3PathFactory
-from wicker.schema import dataparsing, serialization
+from wicker.schema import serialization
 
 SPARK_PARTITION_SIZE = 256
 
@@ -38,49 +40,7 @@ ParsedExample = Dict[str, Any]
 PointerParsedExample = Dict[str, Any]
 
 
-def _persist_spark_partition_wicker(
-    spark_partition_iter: Iterable[Tuple[str, ParsedExample]],
-    dataset_schema: schema.DatasetSchema,
-    target_max_column_file_numrows: int = 50,
-    s3_storage: S3DataStorage = S3DataStorage(),
-    s3_path_factory: S3PathFactory = S3PathFactory(),
-) -> Iterable[Tuple[str, PointerParsedExample]]:
-    """Persists a Spark partition of examples with parsed bytes into S3Storage as ColumnBytesFiles,
-    returning a new Spark partition of examples with heavy-pointers and metadata only.
-    :param spark_partition_iter: Spark partition of `(partition_str, example)`, where `example` is a dictionary of
-        parsed bytes that needs to be uploaded to S3
-    :param dataset_schema: schema of dataset
-    :param target_max_column_file_numrows: Maximum number of rows in column files. Defaults to 50.
-    :param storage: S3DataStorage to use. Defaults to S3DataStorage().
-    :param s3_path_factory: S3PathFactory to use. Defaults to S3PathFactory().
-    :return: a Generator of `(partition_str, example)`, where `example` is a dictionary with heavy-pointers
-        that point to ColumnBytesFiles in S3 in place of the parsed bytes
-    """
-    column_bytes_file_writers: Dict[str, ColumnBytesFileWriter] = {}
-    heavy_pointer_columns = dataset_schema.get_pointer_columns()
-    metadata_columns = dataset_schema.get_non_pointer_columns()
-
-    for partition, example in spark_partition_iter:
-        # Create ColumnBytesFileWriter lazily as required, for each partition
-        if partition not in column_bytes_file_writers:
-            column_bytes_file_writers[partition] = ColumnBytesFileWriter(
-                s3_storage,
-                s3_path_factory,
-                target_file_rowgroup_size=target_max_column_file_numrows,
-            )
-
-        # Write to ColumnBytesFileWriter and return only metadata + heavy-pointers
-        parquet_metadata: Dict[str, Any] = {col: example[col] for col in metadata_columns}
-        for col in heavy_pointer_columns:
-            loc = column_bytes_file_writers[partition].add(col, example[col])
-            parquet_metadata[col] = loc.to_bytes()
-        yield partition, parquet_metadata
-
-    # Flush all writers when finished
-    for partition in column_bytes_file_writers:
-        column_bytes_file_writers[partition].close()
-
-
+# public facing api consistency function
 def persist_wicker_dataset(
     dataset_name: str,
     dataset_version: str,
@@ -88,112 +48,282 @@ def persist_wicker_dataset(
     rdd: pyspark.rdd.RDD[Tuple[str, UnparsedExample]],
     s3_storage: S3DataStorage = S3DataStorage(),
     s3_path_factory: S3PathFactory = S3PathFactory(),
-) -> Dict[str, int]:
-    """Persists a Spark RDD as a Wicker dataset. RDD must be provided as an RDD of Tuples of (partition, UnparsedExample),
-    where `partition` is a string representing the dataset partition (e.g. train/test/eval) for that given row,
-    and `UnparsedExample` is a Python Dict[str, Any] of the (non-validated) data to be written into the dataset.
-
-    This function will perform validations, do a global sort based on primary keys, serialize the examples into bytes,
-    save the data in S3 and persist the written data into the configured Wicker S3 bucket.
-
-    :param dataset_name: name of the dataset
-    :param dataset_version: version of the dataset
-    :param dataset_schema: schema of the dataset
-    :param rdd: RDD of data to be persisted as a Wicker dataset
-    :return: A dictionary of partition name to size
+) -> Optional[Dict[str, int]]:
     """
-    # Write schema to S3
-    schema_path = s3_path_factory.get_dataset_schema_path(DatasetID(name=dataset_name, version=dataset_version))
-    s3_storage.put_object_s3(serialization.dumps(dataset_schema).encode("utf-8"), schema_path)
-
-    # Parse each row to throw errors early if they fail validation
-    def parse_row(data: UnparsedExample) -> ParsedExample:
-        return dataparsing.parse_example(data, dataset_schema)
-
-    rdd0 = rdd.mapValues(parse_row)
-
-    # Make sure to cache the RDD to ease future computations, since it seems that sortBy and zipWithIndex
-    # trigger actions and we want to avoid recomputing the source RDD at all costs
-    rdd0 = rdd0.cache()
-    dataset_size = rdd0.count()
-
-    # Key each row with the partition + primary_keys
-    # (partition, data) -> (primary_key_tup, (partition, data))
-    def get_row_keys(partition_data_tup: Tuple[str, ParsedExample]) -> PrimaryKeyTuple:
-        partition, data = partition_data_tup
-        return (partition,) + tuple(data[pk] for pk in dataset_schema.primary_keys)
-
-    rdd1 = rdd0.keyBy(get_row_keys)
-
-    # Sort RDD by keys
-    rdd2: pyspark.rdd.RDD[Tuple[Tuple[Any, ...], Tuple[str, ParsedExample]]] = rdd1.sortByKey(
-        # TODO(jchia): Magic number, we should derive this based on row size
-        numPartitions=dataset_size // SPARK_PARTITION_SIZE,
-        ascending=True,
+    Persist wicker dataset public facing api function, for api consistency.
+    :param dataset_name: name of dataset persisted
+    :type dataset_name: str
+    :param dataset_version: version of dataset persisted
+    :type dataset_version: str
+    :param dataset_schema: schema of dataset to be persisted
+    :type dataset_schema: DatasetSchema
+    :param rdd: rdd of data to persist
+    :type rdd: RDD
+    :param s3_storage: s3 storage abstraction
+    :type s3_storage: S3DataStorage
+    :param s3_path_factory: s3 path abstraction
+    :type s3_path_factory: S3PathFactory
+    """
+    return SparkPersistor(s3_storage, s3_path_factory).persist_wicker_dataset(
+        dataset_name, dataset_version, dataset_schema, rdd
     )
 
-    def set_partition(iterator: Iterable[PrimaryKeyTuple]) -> Iterable[int]:
-        key_set = set(iterator)
-        yield len(key_set)
 
-    # the number of unique keys in rdd partitions
-    # this is softer check than collecting all the keys in all partitions to check uniqueness9
-    rdd_key_count: int = rdd2.map(lambda x: x[0]).mapPartitions(set_partition).reduce(add)
-    num_unique_keys = rdd_key_count
-    if dataset_size != num_unique_keys:
-        raise WickerDatastoreException(
-            f"""Error: dataset examples do not have unique primary key tuples.
-            Dataset has has {dataset_size} examples but {num_unique_keys} unique primary keys"""
+class SparkPersistor(AbstractDataPersistor):
+    def __init__(
+        self,
+        s3_storage: S3DataStorage = S3DataStorage(),
+        s3_path_factory: S3PathFactory = S3PathFactory(),
+        schema: Optional[schema.DatasetSchema] = None,
+        dataset_name: Optional[str] = None,
+        dataset_version: Optional[str] = None,
+        rdd: Optional[pyspark.rdd.RDD[Tuple[str, UnparsedExample]]] = None,
+    ) -> None:
+        """
+        Init a SparkPersistor
+
+        :param s3_storage: The storage abstraction for S3
+        :type s3_storage: S3DataStore
+        :param s3_path_factory: The path factory for generating s3 paths
+                                based on dataset name and version
+        :type s3_path_factory: S3PathFactory
+        :param schema: Schema of the data
+        :type schema: Dataset schema or none
+        :param dataset_name: Optionally start with name of dataset
+        :type dataset_name: Str or none
+        :param dataset_version: Optionally start with version of dataset
+        :type dataset_version: Str or none
+        :param rdd: Rdd containing the data
+        :type rdd: RDD
+        """
+        super().__init__(s3_storage, s3_path_factory, schema, dataset_name, dataset_version)
+        self._current_rdd = rdd
+
+    def persist_wicker_dataset(
+        self,
+        dataset_name: str,
+        dataset_version: str,
+        dataset_schema: schema.DatasetSchema,
+        dataset: pyspark.rdd.RDD[Tuple[str, UnparsedExample]],
+    ) -> Optional[Dict[str, int]]:
+        """Persists a Spark RDD as a Wicker dataset. RDD must be provided as an RDD of Tuples of (partition, UnparsedExample),
+        where `partition` is a string representing the dataset partition (e.g. train/test/eval) for that given row,
+        and `UnparsedExample` is a Python Dict[str, Any] of the (non-validated) data to be written into the dataset.
+
+        This function will perform validations, do a global sort based on primary keys,
+        serialize the examples into bytes, save the data in S3 and persist the written data
+        into the configured Wicker S3 bucket.
+
+        :param dataset_name: name of the dataset
+        :param dataset_version: version of the dataset
+        :param dataset_schema: schema of the dataset
+        :param dataset: RDD of data to be persisted as a Wicker dataset
+        :return: A dictionary of partition name to size
+        """
+        # Write schema to S3
+        self._current_dataset_name = dataset_name
+        self._current_dataset_version = dataset_version
+        self._current_schema = dataset_schema
+        self._current_rdd = dataset
+
+        return self.persist_current_wicker_dataset()
+
+    def persist_current_wicker_dataset(
+        self,
+    ) -> Optional[Dict[str, int]]:
+        """
+        Persist the current rdd dataset defined by name, version, schema, and data.
+        """
+        # check if variables have been set ie: not None
+        if (
+            not isinstance(self._current_dataset_name, str)
+            or not isinstance(self._current_dataset_version, str)
+            or not isinstance(self._current_schema, schema.DatasetSchema)
+            or not isinstance(self._current_rdd, pyspark.rdd.RDD)
+        ):
+            logging.warning("Current dataset variables not all set, set all to proper not None values")
+            return None
+
+        # define locally for passing to spark rdd ops, breaks if relying on self
+        # since it passes to spark engine and we lose self context
+        current_schema: schema.DatasetSchema = self._current_schema
+        s3_storage = self.s3_storage
+        s3_path_factory = self.s3_path_factory
+        current_dataset_name = self._current_dataset_name
+        current_dataset_version = self._current_dataset_version
+        current_rdd = self._current_rdd
+        parse_row = self.parse_row
+        get_row_keys = self.get_row_keys
+        persist_spark_partition_wicker = self.persist_spark_partition_wicker
+        save_partition_tbl = self.save_partition_tbl
+
+        # put the schema up on to s3
+        schema_path = s3_path_factory.get_dataset_schema_path(
+            DatasetID(name=current_dataset_name, version=current_dataset_version)
+        )
+        s3_storage.put_object_s3(serialization.dumps(current_schema).encode("utf-8"), schema_path)
+
+        # parse the rows and ensure validation passes, ie: rows actual data matches expected types
+        rdd0 = current_rdd.mapValues(lambda row: parse_row(row, current_schema))  # type: ignore
+
+        # Make sure to cache the RDD to ease future computations, since it seems that sortBy and zipWithIndex
+        # trigger actions and we want to avoid recomputing the source RDD at all costs
+        rdd0 = rdd0.cache()
+        dataset_size = rdd0.count()
+
+        rdd1 = rdd0.keyBy(lambda row: get_row_keys(row, current_schema))
+
+        # Sort RDD by keys
+        rdd2: pyspark.rdd.RDD[Tuple[Tuple[Any, ...], Tuple[str, ParsedExample]]] = rdd1.sortByKey(
+            # TODO(jchia): Magic number, we should derive this based on row size
+            numPartitions=dataset_size // SPARK_PARTITION_SIZE,
+            ascending=True,
         )
 
+        def set_partition(iterator: Iterable[PrimaryKeyTuple]) -> Iterable[int]:
+            key_set = set(iterator)
+            yield len(key_set)
+
+        # the number of unique keys in rdd partitions
+        # this is softer check than collecting all the keys in all partitions to check uniqueness9
+        rdd_key_count: int = rdd2.map(lambda x: x[0]).mapPartitions(set_partition).reduce(add)
+        num_unique_keys = rdd_key_count
+        if dataset_size != num_unique_keys:
+            raise WickerDatastoreException(
+                f"""Error: dataset examples do not have unique primary key tuples.
+                Dataset has has {dataset_size} examples but {num_unique_keys} unique primary keys"""
+            )
+
+        # persist the spark partition to S3Storage
+        rdd3 = rdd2.values()
+        rdd4 = rdd3.mapPartitions(
+            lambda spark_iterator: persist_spark_partition_wicker(
+                spark_iterator,
+                current_schema,
+                s3_storage,
+                s3_path_factory,
+                # TODO(jchia): Magic number, we should derive this based on row size
+                target_max_column_file_numrows=50,
+            )
+        )
+
+        # combine the rdd by the keys in the pyarrow table
+        rdd5 = rdd4.combineByKey(
+            createCombiner=lambda data: pa.Table.from_pydict(
+                {col: [data[col]] for col in current_schema.get_all_column_names()}
+            ),
+            mergeValue=lambda tbl, data: pa.Table.from_batches(
+                [
+                    *tbl.to_batches(),  # type: ignore
+                    *pa.Table.from_pydict(
+                        {col: [data[col]] for col in current_schema.get_all_column_names()}
+                    ).to_batches(),
+                ]
+            ),
+            mergeCombiners=lambda tbl1, tbl2: pa.Table.from_batches(
+                [
+                    *tbl1.to_batches(),  # type: ignore
+                    *tbl2.to_batches(),  # type: ignore
+                ]
+            ),
+        )
+        # create the partition tables
+        rdd6 = rdd5.mapValues(
+            lambda pa_tbl: pc.take(
+                pa_tbl,
+                pc.sort_indices(
+                    pa_tbl,
+                    sort_keys=[(pk, "ascending") for pk in current_schema.primary_keys],
+                ),
+            )
+        )
+        # save the parition table to s3
+        rdd7 = rdd6.map(
+            lambda partition_table: save_partition_tbl(
+                partition_table, current_dataset_name, current_dataset_version, s3_storage, s3_path_factory
+            )
+        )
+        written = rdd7.collect()
+
+        return {partition: size for partition, size in written}
+
+    @staticmethod
+    def get_row_keys(partition_data_tup: Tuple[str, ParsedExample], schema: schema.DatasetSchema) -> PrimaryKeyTuple:
+        """
+        Get the keys of a row based on the parition tuple and the data schema.
+
+        :param partition_data_tup: Tuple of partition id and ParsedExample row
+        :type partition_data_tup: Tuple[str, ParsedExample]
+        :return: Tuple of primary key values from parsed row and schema
+        :rtype: PrimaryKeyTuple
+        """
+        partition, data = partition_data_tup
+        return (partition,) + tuple(data[pk] for pk in schema.primary_keys)
+
     # Write data to Column Byte Files
-    rdd3 = rdd2.values()
-    rdd4 = rdd3.mapPartitions(
-        lambda spark_iterator: _persist_spark_partition_wicker(
-            spark_iterator,
-            dataset_schema,
-            # TODO(jchia): Magic number, we should derive this based on row size
-            target_max_column_file_numrows=50,
+    @staticmethod
+    def persist_spark_partition_wicker(
+        spark_partition_iter: Iterable[Tuple[str, ParsedExample]],
+        schema: schema.DatasetSchema,
+        s3_storage: S3DataStorage,
+        s3_path_factory: S3PathFactory,
+        target_max_column_file_numrows: int = 50,
+    ) -> Iterable[Tuple[str, PointerParsedExample]]:
+        """Persists a Spark partition of examples with parsed bytes into S3Storage as ColumnBytesFiles,
+        returning a new Spark partition of examples with heavy-pointers and metadata only.
+        :param spark_partition_iter: Spark partition of `(partition_str, example)`, where `example`
+            is a dictionary of parsed bytes that needs to be uploaded to S3
+        :param target_max_column_file_numrows: Maximum number of rows in column files. Defaults to 50.
+        :return: a Generator of `(partition_str, example)`, where `example` is a dictionary with heavy-pointers
+            that point to ColumnBytesFiles in S3 in place of the parsed bytes
+        """
+        column_bytes_file_writers: Dict[str, ColumnBytesFileWriter] = {}
+        heavy_pointer_columns = schema.get_pointer_columns()
+        metadata_columns = schema.get_non_pointer_columns()
+
+        for partition, example in spark_partition_iter:
+            # Create ColumnBytesFileWriter lazily as required, for each partition
+            if partition not in column_bytes_file_writers:
+                column_bytes_file_writers[partition] = ColumnBytesFileWriter(
+                    s3_storage,
+                    s3_path_factory,
+                    target_file_rowgroup_size=target_max_column_file_numrows,
+                )
+
+            # Write to ColumnBytesFileWriter and return only metadata + heavy-pointers
+            parquet_metadata: Dict[str, Any] = {col: example[col] for col in metadata_columns}
+            for col in heavy_pointer_columns:
+                loc = column_bytes_file_writers[partition].add(col, example[col])
+                parquet_metadata[col] = loc.to_bytes()
+            yield partition, parquet_metadata
+
+        # Flush all writers when finished
+        for partition in column_bytes_file_writers:
+            column_bytes_file_writers[partition].close()
+
+    # sort the indices of the primary keys in ascending order
+    @staticmethod
+    def save_partition_tbl(
+        partition_table_tuple: Tuple[str, pa.Table],
+        current_dataset_name: str,
+        current_dataset_version: str,
+        s3_storage: S3DataStorage,
+        s3_path_factory: S3PathFactory,
+    ) -> Tuple[str, int]:
+        """
+        Save a partition table to s3 under the dataset name and version.
+
+        :param partition_table_tuple: Tuple of partition id and pyarrow table to save
+        :type partition_table_tuple: Tuple[str, pyarrow.Table]
+        :return: A tuple containing the paritiion id and the num of saved rows
+        :rtype: Tuple[str, int]
+        """
+        partition, pa_tbl = partition_table_tuple
+        save_index(
+            current_dataset_name,
+            current_dataset_version,
+            {partition: pa_tbl},
             s3_storage=s3_storage,
             s3_path_factory=s3_path_factory,
         )
-    )
-
-    # For each dataset partition, persist the metadata as a Parquet file in S3
-    def save_partition_tbl(partition_table_tuple: Tuple[str, pa.Table]) -> Tuple[str, int]:
-        partition, pa_tbl = partition_table_tuple
-        save_index(
-            dataset_name, dataset_version, {partition: pa_tbl}, s3_storage=s3_storage, s3_path_factory=s3_path_factory
-        )
         return (partition, pa_tbl.num_rows)
-
-    rdd5 = rdd4.combineByKey(
-        createCombiner=lambda data: pa.Table.from_pydict(
-            {col: [data[col]] for col in dataset_schema.get_all_column_names()}
-        ),
-        mergeValue=lambda tbl, data: pa.Table.from_batches(
-            [
-                *tbl.to_batches(),  # type: ignore
-                *pa.Table.from_pydict({col: [data[col]] for col in dataset_schema.get_all_column_names()}).to_batches(),
-            ]
-        ),
-        mergeCombiners=lambda tbl1, tbl2: pa.Table.from_batches(
-            [
-                *tbl1.to_batches(),  # type: ignore
-                *tbl2.to_batches(),  # type: ignore
-            ]
-        ),
-    )
-    rdd6 = rdd5.mapValues(
-        lambda pa_tbl: pc.take(
-            pa_tbl,
-            pc.sort_indices(
-                pa_tbl,
-                sort_keys=[(pk, "ascending") for pk in dataset_schema.primary_keys],
-            ),
-        )
-    )
-    rdd7 = rdd6.map(save_partition_tbl)
-    written = rdd7.collect()
-
-    return {partition: size for partition, size in written}

--- a/wicker/plugins/spark.py
+++ b/wicker/plugins/spark.py
@@ -3,8 +3,6 @@
 This plugin does an expensive global sorting step using Spark, which could be prohibitive
 for large datasets.
 """
-
-
 from __future__ import annotations
 
 from typing import Any, Dict, Iterable, Optional, Tuple
@@ -32,6 +30,7 @@ from wicker.core.storage import S3DataStorage, S3PathFactory
 from wicker.schema import serialization
 
 SPARK_PARTITION_SIZE = 256
+MAX_COL_FILE_NUMROW = 50  # TODO(isaak-willett): Magic number, we should derive this based on row size
 
 PrimaryKeyTuple = Tuple[Any, ...]
 UnparsedExample = Dict[str, Any]
@@ -155,8 +154,7 @@ class SparkPersistor(AbstractDataPersistor):
                 schema,
                 s3_storage,
                 s3_path_factory,
-                # TODO(jchia): Magic number, we should derive this based on row size
-                target_max_column_file_numrows=50,
+                target_max_column_file_numrows=MAX_COL_FILE_NUMROW,
             )
         )
 

--- a/wicker/plugins/spark.py
+++ b/wicker/plugins/spark.py
@@ -7,7 +7,6 @@ for large datasets.
 
 from __future__ import annotations
 
-import logging
 from typing import Any, Dict, Iterable, Optional, Tuple
 
 import pyarrow as pa
@@ -102,8 +101,7 @@ class SparkPersistor(AbstractDataPersistor):
             or not isinstance(schema, schema_module.DatasetSchema)
             or not isinstance(rdd, pyspark.rdd.RDD)
         ):
-            logging.warning("Current dataset variables not all set, set all to proper not None values")
-            return None
+            raise ValueError("Current dataset variables not all set, set all to proper not None values")
 
         # define locally for passing to spark rdd ops, breaks if relying on self
         # since it passes to spark engine and we lose self context
@@ -140,7 +138,7 @@ class SparkPersistor(AbstractDataPersistor):
             yield len(key_set)
 
         # the number of unique keys in rdd partitions
-        # this is softer check than collecting all the keys in all partitions to check uniqueness9
+        # this is softer check than collecting all the keys in all partitions to check uniqueness
         rdd_key_count: int = rdd2.map(lambda x: x[0]).mapPartitions(set_partition).reduce(add)
         num_unique_keys = rdd_key_count
         if dataset_size != num_unique_keys:


### PR DESCRIPTION
## Overview:
We need to add a second persistence method free of spark and dynamodb and flyte, this can be better achieved by abstracting meaningful parts away from specific implementations so we have a base to build off. This does the abstraction of persistence in spark away from just a single functional entry point to a class -> base class system. Doing this alleviates some pain in the future by allowing for developers to more easily make a new persistence method by just inheriting off the base class and knowing what methods to make and what types they need. This is a good step in un-sparking the core features of wicker.

## Changes:
- Adds new module `wicker.core.persistence`
- Adds base class called `AbstractDataPersistor` to `wicker.core.persistence`
- Adds methods with types that need to be created with proper un implemented exceptions in base class
- Changes `wicker.plugins.spark` to be class based and inherit off of `AbstractDataPersistor`
- Changes all examples to show new paradigm of operation
- Keeps API for actually calling this consistent, keeps public function that builds class and demolishes class on completion

## Performance/Maintenance Considerations:
- No performance loss of persisted dataset tests I've run manually
- No notable memory additions, only a few kbs for the class abstraction
- Additional code lines added but they simplified api, minimal impact

## Tests/Validation:
Tests were left almost unchanged as API has been left consistent, please examine test runs and validate they pass for you. Additionally the getting started was changed but that's to show off the now correct API usage as this is the direction I would like the persistence API to move, class based over functional at least for this.