### PR TITLE
chore: add marccarre to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @aalavian @anantsimran @isaak-willett @varshaparthay @chrisochoatri
+*       @aalavian @anantsimran @isaak-willett @marccarre @varshaparthay @chrisochoatri

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @aalavian @anantsimran @isaak-willett @marccarre @chrisochoatri
+*       @aalavian @anantsimran @chrisochoatri @isaak-willett @marccarre

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @aalavian @anantsimran @isaak-willett @marccarre @varshaparthay @chrisochoatri
+*       @aalavian @anantsimran @isaak-willett @marccarre @chrisochoatri


### PR DESCRIPTION
## Changelog

- Added `marccarre` to `CODEOWNERS`, as new maintainer.
- Removed `varshaparthay` from `CODEOWNERS`, as no longer a maintainer.
- Sorted maintainers alphabetically, for better readability.

## Reason

@marccarre is a new maintainer for Wicker and needs to be added to `CODEOWNERS`, to be able to approve pull requests, given the following policy:

    At least 2 approving reviews are required to merge this pull request.