### PR TITLE
Add filters parameter to the S3Dataset constructor

### DIFF
--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -119,11 +119,12 @@ class TestS3Dataset(unittest.TestCase):
                 storage=fake_s3_storage,
                 s3_path_factory=None,
                 pa_filesystem=pafs.LocalFileSystem(),
-                filters=("foo", "in", filtered_value_list),
+                filters=[("foo", "in", filtered_value_list)],
             )
             self.assertEqual(len(ds), len(filtered_value_list))
             retrived_values_list = [row["foo"] for row in ds]
             retrived_values_list.sort()
+            filtered_value_list.sort()
             self.assertListEqual(retrived_values_list, filtered_value_list)
 
     def test_dataset_size(self) -> None:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -107,6 +107,25 @@ class TestS3Dataset(unittest.TestCase):
                 self.assertEqual(retrieved["foo"], reference["foo"])
                 np.testing.assert_array_equal(retrieved["np_arr"], reference["np_arr"])
 
+    def test_filters_dataset(self) -> None:
+        filtered_value_list = [f"bar{i}" for i in range(100)]
+        with self._setup_storage() as (fake_s3_storage, fake_s3_path_factory, tmpdir):
+            ds = S3Dataset(
+                FAKE_NAME,
+                FAKE_VERSION,
+                FAKE_PARTITION,
+                local_cache_path_prefix=tmpdir,
+                columns_to_load=None,
+                storage=fake_s3_storage,
+                s3_path_factory=None,
+                pa_filesystem=pafs.LocalFileSystem(),
+                filters=("foo", "in", filtered_value_list),
+            )
+            self.assertEqual(len(ds), len(filtered_value_list))
+            retrived_values_list = [row["foo"] for row in ds]
+            retrived_values_list.sort()
+            self.assertListEqual(retrived_values_list, filtered_value_list)
+
     def test_dataset_size(self) -> None:
         with self._setup_storage() as (fake_s3_storage, fake_s3_path_factory, tmpdir):
             # overwrite the mocked resource function using the fake storage

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -122,10 +122,10 @@ class TestS3Dataset(unittest.TestCase):
                 filters=[("foo", "in", filtered_value_list)],
             )
             self.assertEqual(len(ds), len(filtered_value_list))
-            retrived_values_list = [ds[i]["foo"] for i in range(len(ds))]
-            retrived_values_list.sort()
+            retrieved_values_list = [ds[i]["foo"] for i in range(len(ds))]
+            retrieved_values_list.sort()
             filtered_value_list.sort()
-            self.assertListEqual(retrived_values_list, filtered_value_list)
+            self.assertListEqual(retrieved_values_list, filtered_value_list)
 
     def test_dataset_size(self) -> None:
         with self._setup_storage() as (fake_s3_storage, fake_s3_path_factory, tmpdir):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -122,7 +122,7 @@ class TestS3Dataset(unittest.TestCase):
                 filters=[("foo", "in", filtered_value_list)],
             )
             self.assertEqual(len(ds), len(filtered_value_list))
-            retrived_values_list = [row["foo"] for row in ds]
+            retrived_values_list = [ds[i]["foo"] for i in range(len(ds))]
             retrived_values_list.sort()
             filtered_value_list.sort()
             self.assertListEqual(retrived_values_list, filtered_value_list)

--- a/wicker/core/datasets.py
+++ b/wicker/core/datasets.py
@@ -150,6 +150,7 @@ class S3Dataset(AbstractDataset):
         pa_filesystem: Optional[pafs.FileSystem] = None,
         filelock_timeout_seconds: int = FILE_LOCK_TIMEOUT_SECONDS,
         treat_objects_as_bytes: bool = False,
+        filters=None,
     ):
         """Initializes an S3Dataset
 
@@ -160,7 +161,10 @@ class S3Dataset(AbstractDataset):
         :param data_service: S3DataService instance to use, defaults to None which uses default initializations
         :param filelock_timeout_seconds: number of seconds after which to timeout on waiting for downloads,
             defaults to FILE_LOCK_TIMEOUT_SECONDS
-        :param treat_objects_as_bytes: If set, don't try to decode ObjectFields and keep them as binary data.
+        :param treat_objects_as_bytes: If set, don't try to decode ObjectFields and keep them as binary data
+        :param filters: Rows which do not match the filter predicate will be removed, defaults to None
+        :type filters: pyarrow.compute.Expression, List[Tuple], or List[List[Tuple]], optional
+        .. seealso:: `filters in ParquetDataset <https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetDataset.html#pyarrow.parquet.ParquetDataset>`__ # noqa
         """
         super().__init__()
         self._columns_to_load: Optional[List[str]] = columns_to_load

--- a/wicker/core/datasets.py
+++ b/wicker/core/datasets.py
@@ -164,7 +164,7 @@ class S3Dataset(AbstractDataset):
         :param treat_objects_as_bytes: If set, don't try to decode ObjectFields and keep them as binary data
         :param filters: Rows which do not match the filter predicate will be removed, defaults to None
         :type filters: pyarrow.compute.Expression, List[Tuple], or List[List[Tuple]], optional
-        .. seealso:: `filters in ParquetDataset <https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetDataset.html#pyarrow.parquet.ParquetDataset>`__ # noqa
+        .. seealso:: `filters in <https://arrow.apache.org/docs/python/generated/pyarrow.parquet.read_table.html>`__ # noqa
         """
         super().__init__()
         self._columns_to_load: Optional[List[str]] = columns_to_load
@@ -193,6 +193,7 @@ class S3Dataset(AbstractDataset):
             self._dataset_id,
             schema=self.schema(),
         )
+        self.filters = filters
 
     def schema(self) -> DatasetSchema:
         if self._schema is None:
@@ -209,7 +210,9 @@ class S3Dataset(AbstractDataset):
     def arrow_table(self) -> pyarrow.Table:
         path = self._s3_path_factory.get_dataset_partition_path(self._partition, s3_prefix=False)
         if not self._arrow_table:
-            self._arrow_table = papq.read_table(path, columns=self._columns_to_load, filesystem=self._pa_filesystem)
+            self._arrow_table = papq.read_table(
+                path, columns=self._columns_to_load, filesystem=self._pa_filesystem, filters=self.filters
+            )
         return self._arrow_table
 
     def __len__(self) -> int:

--- a/wicker/core/datasets.py
+++ b/wicker/core/datasets.py
@@ -162,7 +162,7 @@ class S3Dataset(AbstractDataset):
         :param filelock_timeout_seconds: number of seconds after which to timeout on waiting for downloads,
             defaults to FILE_LOCK_TIMEOUT_SECONDS
         :param treat_objects_as_bytes: If set, don't try to decode ObjectFields and keep them as binary data
-        :param filters: Rows which do not match the filter predicate will be removed, defaults to None
+        :param filters: Only returns rows which match the filter. Defaults to None, i.e., returns all rows.
         :type filters: pyarrow.compute.Expression, List[Tuple], or List[List[Tuple]], optional
         .. seealso:: `filters in <https://arrow.apache.org/docs/python/generated/pyarrow.parquet.read_table.html>`__ # noqa
         """


### PR DESCRIPTION
## Overview
To give the end user of S3Dataset more flexibility, this PR adds a filters parameters to the S3Dataset Constructor. 
The filters is passed to the Pyarrow parquet read_table, so follows the syntax of filters on https://arrow.apache.org/docs/python/generated/pyarrow.parquet.read_table.html.

## Notes
- This is backwards compatible because the `filters` parameter is set to None by default.

## Limits
- The syntax of the filters has been bound to Pyarrow which makes it harder to migrate to the other IO lib like [polars](https://pola.rs/), but since the wicker dataset already been [bound to the Pyarrow ecosystem](https://github.com/woven-planet/wicker/blob/main/wicker/core/datasets.py#L133), it should not be a problem in the shorterm
## Added

- Filters parameter in S3Dataset constructor
- test_filters_dataset in test_datasets 

## Testing
- CI
