### PR TITLE
Add a column file reader that can read from local filesystems

### DIFF
--- a/tests/test_column_files.py
+++ b/tests/test_column_files.py
@@ -206,7 +206,7 @@ class TestColumnBytesFileCacheAndReader(unittest.TestCase):
 
         # Mock the helper function that just opens a file and returns its contents.
         read_column_bytes_file_mock = MagicMock(return_value=FAKE_BYTES)
-        cbf_cache._read_column_bytes_file = read_column_bytes_file_mock
+        cbf_cache._read_column_bytes_file = read_column_bytes_file_mock  # type: ignore
 
         # Read back the column file.
         bytes_read = cbf_cache.read(info)
@@ -220,7 +220,7 @@ class TestColumnBytesFileCacheAndReader(unittest.TestCase):
 
         # Reset the reader function mock so we can check that it was called just once.
         read_column_bytes_file_mock = MagicMock(return_value=FAKE_BYTES)
-        cbf_reader._read_column_bytes_file = read_column_bytes_file_mock
+        cbf_reader._read_column_bytes_file = read_column_bytes_file_mock  # type: ignore
 
         bytes_read = cbf_reader.read(info)
         read_column_bytes_file_mock.assert_called_once_with(

--- a/tests/test_column_files.py
+++ b/tests/test_column_files.py
@@ -7,10 +7,11 @@ from unittest.mock import MagicMock
 from wicker.core.column_files import (
     ColumnBytesFileCache,
     ColumnBytesFileLocationV1,
+    ColumnBytesFileReader,
     ColumnBytesFileWriter,
 )
 from wicker.core.definitions import DatasetID, DatasetPartition
-from wicker.core.storage import S3PathFactory
+from wicker.core.storage import S3PathFactory, WickerPathFactory
 from wicker.testing.storage import FakeS3DataStorage
 
 FAKE_SHARD_ID = "fake_shard_id"
@@ -176,7 +177,7 @@ class TestColumnBytesFileWriter(unittest.TestCase):
                 self.assertNotEqual(info2.file_id, info3.file_id)
 
 
-class TestColumnBytesFileCache(unittest.TestCase):
+class TestColumnBytesFileCacheAndReader(unittest.TestCase):
     def test_write_one_column_one_row_and_read(self) -> None:
         path_factory = S3PathFactory()
         mock_storage = MagicMock()
@@ -195,7 +196,7 @@ class TestColumnBytesFileCache(unittest.TestCase):
         mock_storage.put_file_s3.assert_called_once_with(unittest.mock.ANY, s3_path)
 
         # Now, verify that we can read it back from mock storage.
-        local_path = os.path.join("/tmp", s3_path.split("s3://")[1])
+        local_path = os.path.join("/tmp", s3_path.split("s3://fake_data/")[1])
         mock_storage.fetch_file = MagicMock(return_value=local_path)
 
         cbf_cache = ColumnBytesFileCache(
@@ -204,12 +205,28 @@ class TestColumnBytesFileCache(unittest.TestCase):
         )
 
         # Mock the helper function that just opens a file and returns its contents.
-        read_column_bytes_file = MagicMock(return_value=FAKE_BYTES)
-        cbf_cache._read_column_bytes_file = read_column_bytes_file
+        read_column_bytes_file_mock = MagicMock(return_value=FAKE_BYTES)
+        cbf_cache._read_column_bytes_file = read_column_bytes_file_mock
 
         # Read back the column file.
         bytes_read = cbf_cache.read(info)
         mock_storage.fetch_file.assert_called_once_with(s3_path, "/tmp", timeout_seconds=-1)
+        self.assertEqual(len(bytes_read), len(FAKE_BYTES))
+        self.assertEqual(bytes_read, FAKE_BYTES)
+
+        # Now let's verify that we can use the reader directly to read the local column bytes.
+        wicker_path_factory = WickerPathFactory("/tmp")
+        cbf_reader = ColumnBytesFileReader(wicker_path_factory)
+
+        # Reset the reader function mock so we can check that it was called just once.
+        read_column_bytes_file_mock = MagicMock(return_value=FAKE_BYTES)
+        cbf_reader._read_column_bytes_file = read_column_bytes_file_mock
+
+        bytes_read = cbf_reader.read(info)
+        read_column_bytes_file_mock.assert_called_once_with(
+            column_bytes_file_info=info,
+            column_bytes_file_path=local_path,
+        )
         self.assertEqual(len(bytes_read), len(FAKE_BYTES))
         self.assertEqual(bytes_read, FAKE_BYTES)
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -97,7 +97,7 @@ class TestS3Dataset(unittest.TestCase):
                 local_cache_path_prefix=tmpdir,
                 columns_to_load=None,
                 storage=fake_s3_storage,
-                s3_path_factory=None,
+                s3_path_factory=fake_s3_path_factory,
                 pa_filesystem=pafs.LocalFileSystem(),
             )
 
@@ -117,7 +117,7 @@ class TestS3Dataset(unittest.TestCase):
                 local_cache_path_prefix=tmpdir,
                 columns_to_load=None,
                 storage=fake_s3_storage,
-                s3_path_factory=None,
+                s3_path_factory=fake_s3_path_factory,
                 pa_filesystem=pafs.LocalFileSystem(),
                 filters=[("foo", "in", filtered_value_list)],
             )

--- a/wicker/core/column_files.py
+++ b/wicker/core/column_files.py
@@ -228,8 +228,8 @@ class ColumnBytesFileReader:
         self,
         example: validation.AvroRecord,
         schema: schema.DatasetSchema,
-    ):
-        visitor = ResolvePointersVisitor(self, example, schema)
+    ) -> validation.AvroRecord:
+        visitor = ResolvePointersVisitor(example, schema, self)
         return visitor.resolve_pointers()
 
 

--- a/wicker/core/column_files.py
+++ b/wicker/core/column_files.py
@@ -253,7 +253,7 @@ class ColumnBytesFileCache(ColumnBytesFileReader):
         :type filelock_timeout_seconds: int, optional
         :param path_factory: Path factory for determining paths to col files from root
         :type path_factory: WickerPathFactory, defaults to S3PathFactory
-        :param storage: Storage used for grabbing files. Defaults to nont and creates S3DataStorage if none.
+        :param storage: Storage used for grabbing files. Defaults to S3DataStorage if None.
         :type storage: Optional[AbstractDataStorage]
         :param dataset_name: name of the dataset, defaults to None
         :type dataset_name: str, optional

--- a/wicker/core/column_files.py
+++ b/wicker/core/column_files.py
@@ -279,8 +279,6 @@ class ColumnBytesFileCache(ColumnBytesFileReader):
             self._column_bytes_root_path, str(column_bytes_file_info.file_id)
         )
 
-        print("ALEX CBF read path", column_concatenated_bytes_file_path, "_rp is", self._root_path)
-
         local_path = self._storage.fetch_file(
             column_concatenated_bytes_file_path,
             self._root_path,

--- a/wicker/core/column_files.py
+++ b/wicker/core/column_files.py
@@ -15,7 +15,12 @@ import uuid
 from types import TracebackType
 from typing import IO, Any, Dict, List, Literal, Optional, Tuple, Type
 
-from wicker.core.storage import AbstractDataStorage, S3DataStorage, S3PathFactory, WickerPathFactory
+from wicker.core.storage import (
+    AbstractDataStorage,
+    S3DataStorage,
+    S3PathFactory,
+    WickerPathFactory,
+)
 from wicker.schema import schema, validation
 
 

--- a/wicker/core/column_files.py
+++ b/wicker/core/column_files.py
@@ -15,7 +15,7 @@ import uuid
 from types import TracebackType
 from typing import IO, Any, Dict, List, Literal, Optional, Tuple, Type
 
-from wicker.core.storage import S3DataStorage, S3PathFactory
+from wicker.core.storage import AbstractDataStorage, S3DataStorage, S3PathFactory, WickerPathFactory
 from wicker.schema import schema, validation
 
 
@@ -178,15 +178,70 @@ class ColumnBytesFileWriter:
         self.write_buffers[column_name] = self._get_new_buffer()
 
 
-class ColumnBytesFileCache:
+class ColumnBytesFileReader:
+    """A reader class for column bytes files to inherit upon for caches and cacheless"""
+
+    def __init__(
+        self,
+        dataset_name: Optional[str] = None,
+        path_factory: WickerPathFactory = S3PathFactory(),
+    ) -> None:
+        self._column_bytes_root_path = path_factory._get_column_concatenated_bytes_files_path(dataset_name=dataset_name)
+        self._dataset_name = dataset_name
+        self._path_factory = path_factory
+
+    def _read_column_bytes_file(
+        self, column_bytes_file_info: ColumnBytesFileLocationV1, column_bytes_file_path: str
+    ) -> bytes:
+        """Read a column bytes file in a standard location.
+
+        Reads the column bytes file from the column bytes info class.
+
+        Args:
+            column_bytes_file_info (ColumnBytesFileLocationV1): Location info for a ColumnBytes
+            file.
+            column_bytes_file_path (str): Path where the ColumnBytes file is written from which to read.
+
+        Returns:
+            bytes: File bytes corresponding to column bytes data.
+        """
+        with open(column_bytes_file_path, "rb") as f:
+            f.seek(column_bytes_file_info.byte_offset)
+            return f.read(column_bytes_file_info.data_size)
+
+    def read(self, column_bytes_file_info: ColumnBytesFileLocationV1) -> bytes:
+        """Read data from column bytes file.
+
+        :param column_bytes_file_info: Location object to column bytes file on data store
+        :type column_bytes_file_info: ColumnBytesFileLocationV1
+        :return: bytes read from the column bytes file
+        """
+        column_concatenated_bytes_file_path = os.path.join(
+            self._column_bytes_root_path, str(column_bytes_file_info.file_id)
+        )
+
+        return self._read_column_bytes_file(
+            column_bytes_file_info=column_bytes_file_info, column_bytes_file_path=column_concatenated_bytes_file_path
+        )
+
+    def resolve_pointers(
+        self,
+        example: validation.AvroRecord,
+        schema: schema.DatasetSchema,
+    ):
+        visitor = ResolvePointersVisitor(self, example, schema)
+        return visitor.resolve_pointers()
+
+
+class ColumnBytesFileCache(ColumnBytesFileReader):
     """A read-through caching abstraction for accessing ColumnBytesFiles"""
 
     def __init__(
         self,
         local_cache_path_prefix: str = "/tmp",
         filelock_timeout_seconds: int = -1,
-        path_factory: S3PathFactory = S3PathFactory(),
-        storage: Optional[S3DataStorage] = None,
+        path_factory: WickerPathFactory = S3PathFactory(),
+        storage: Optional[AbstractDataStorage] = None,
         dataset_name: str = None,
     ):
         """Initializes a ColumnBytesFileCache
@@ -196,37 +251,38 @@ class ColumnBytesFileCache:
         :param filelock_timeout_seconds: number of seconds after which to timeout on waiting for downloads,
             defaults to -1 which indicates to wait forever
         :type filelock_timeout_seconds: int, optional
+        :param path_factory: Path factory for determining paths to col files from root
+        :type path_factory: WickerPathFactory, defaults to S3PathFactory
+        :param storage: Storage used for grabbing files. Defaults to nont and creates S3DataStorage if none.
+        :type storage: Optional[AbstractDataStorage]
         :param dataset_name: name of the dataset, defaults to None
         :type dataset_name: str, optional
         """
-        self._s3_storage = storage if storage is not None else S3DataStorage()
+        super().__init__(dataset_name=dataset_name, path_factory=path_factory)
+        self._storage = storage if storage is not None else S3DataStorage()
         self._root_path = local_cache_path_prefix
         self._filelock_timeout_seconds = filelock_timeout_seconds
-        self._columns_root_path = path_factory.get_column_concatenated_bytes_files_path(dataset_name=dataset_name)
 
-    def read(
-        self,
-        cbf_info: ColumnBytesFileLocationV1,
-    ) -> bytes:
-        column_concatenated_bytes_file_path = os.path.join(self._columns_root_path, str(cbf_info.file_id))
+    def read(self, column_bytes_file_info: ColumnBytesFileLocationV1) -> bytes:
+        """Read data from column bytes file.
 
-        local_path = self._s3_storage.fetch_file(
+        :param column_bytes_file_info: Location object to column bytes file on data store
+        :type column_bytes_file_info: ColumnBytesFileLocationV1
+        :return: bytes read from the column bytes file
+        """
+        column_concatenated_bytes_file_path = os.path.join(
+            self._column_bytes_root_path, str(column_bytes_file_info.file_id)
+        )
+
+        local_path = self._storage.fetch_file(
             column_concatenated_bytes_file_path,
             self._root_path,
             timeout_seconds=self._filelock_timeout_seconds,
         )
 
-        with open(local_path, "rb") as f:
-            f.seek(cbf_info.byte_offset)
-            return f.read(cbf_info.data_size)
-
-    def resolve_pointers(
-        self,
-        example: validation.AvroRecord,
-        schema: schema.DatasetSchema,
-    ) -> validation.AvroRecord:
-        visitor = ResolvePointersVisitor(example, schema, self)
-        return visitor.resolve_pointers()
+        return self._read_column_bytes_file(
+            column_bytes_file_info=column_bytes_file_info, column_bytes_file_path=local_path
+        )
 
 
 class ResolvePointersVisitor(schema.DatasetSchemaVisitor[Any]):
@@ -238,9 +294,10 @@ class ResolvePointersVisitor(schema.DatasetSchemaVisitor[Any]):
         self,
         example: validation.AvroRecord,
         schema: schema.DatasetSchema,
-        cbf_cache: ColumnBytesFileCache,
+        cbf_reader: ColumnBytesFileReader,
     ):
-        self.cbf_cache = cbf_cache
+        self.cbf_cache = cbf_reader  # Set for backwards compatibility only - please use self.cbf_reader
+        self.cbf_reader = cbf_reader
 
         # Pointers to original data (data should be kept immutable)
         self._schema = schema
@@ -317,4 +374,4 @@ class ResolvePointersVisitor(schema.DatasetSchemaVisitor[Any]):
         if data is None:
             return data
         cbf_info = ColumnBytesFileLocationV1.from_bytes(data)
-        return self.cbf_cache.read(cbf_info)
+        return self.cbf_reader.read(cbf_info)

--- a/wicker/core/column_files.py
+++ b/wicker/core/column_files.py
@@ -183,8 +183,8 @@ class ColumnBytesFileReader:
 
     def __init__(
         self,
+        path_factory: WickerPathFactory,
         dataset_name: Optional[str] = None,
-        path_factory: WickerPathFactory = S3PathFactory(),
     ) -> None:
         self._column_bytes_root_path = path_factory._get_column_concatenated_bytes_files_path(dataset_name=dataset_name)
         self._dataset_name = dataset_name
@@ -258,7 +258,7 @@ class ColumnBytesFileCache(ColumnBytesFileReader):
         :param dataset_name: name of the dataset, defaults to None
         :type dataset_name: str, optional
         """
-        super().__init__(dataset_name=dataset_name, path_factory=path_factory)
+        super().__init__(path_factory, dataset_name=dataset_name)
         self._storage = storage if storage is not None else S3DataStorage()
         self._root_path = local_cache_path_prefix
         self._filelock_timeout_seconds = filelock_timeout_seconds

--- a/wicker/core/column_files.py
+++ b/wicker/core/column_files.py
@@ -279,6 +279,8 @@ class ColumnBytesFileCache(ColumnBytesFileReader):
             self._column_bytes_root_path, str(column_bytes_file_info.file_id)
         )
 
+        print("ALEX CBF read path", column_concatenated_bytes_file_path, "_rp is", self._root_path)
+
         local_path = self._storage.fetch_file(
             column_concatenated_bytes_file_path,
             self._root_path,


### PR DESCRIPTION
Let's pull out a piece from https://github.com/woven-planet/wicker/pull/57 that adds a column file reader that can read from local filesystems. Currently, the `ColumnBytesFileCache` always downloads column files from S3 into the local filesystem (under `/tmp` by default) in order to read them.

Let's refactor this slightly so that the `ColumnFileBytesCache` still takes care of downloading column files from S3 into local storage, but has a new parent class `ColumnBytesFileReader` that reads them (from local storage).

TESTING:
- I wrote a new unit test to cover the existing `ColumnBytesFileWriter` class (which did not have a unit test) as well as using the standalone `ColumnBytesFileReader` class.
- Since the change is so small and covered with a new unit test, let us wait to run some test training jobs until the next PR.