### PR TITLE
Add BaseDataset and FileSystemDataset

### DIFF
--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -11,9 +11,9 @@ import pyarrow.fs as pafs  # type: ignore
 import pyarrow.parquet as papq  # type: ignore
 
 from wicker.core.column_files import ColumnBytesFileWriter
-from wicker.core.datasets import S3Dataset
+from wicker.core.datasets import FileSystemDataset, S3Dataset
 from wicker.core.definitions import DatasetID, DatasetPartition
-from wicker.core.storage import S3PathFactory
+from wicker.core.storage import FileSystemDataStorage, S3PathFactory, WickerPathFactory
 from wicker.schema import schema, serialization
 from wicker.testing.storage import FakeS3DataStorage
 
@@ -45,6 +45,78 @@ def cwd(path):
         yield
     finally:
         os.chdir(oldpwd)
+
+
+def get_size(start_path="."):
+    total_byte_size = 0
+    for dir_path, dirnames, filenames in os.walk(start_path):
+        for filename in filenames:
+            # skip if lock, success, or avro file
+            if "lock" not in filename and "success" not in filename and "avro" not in filename:
+                file_path = os.path.join(dir_path, filename)
+                # skip any symlinks (not in wicker but still test)
+                if not os.path.islink(file_path):
+                    total_byte_size += os.path.getsize(file_path)
+
+    return total_byte_size
+
+
+class TestFileSystemDataset(unittest.TestCase):
+    @contextmanager
+    def _setup_storage(self) -> Iterator[Tuple[FileSystemDataStorage, WickerPathFactory, str]]:
+        with tempfile.TemporaryDirectory() as tmpdir, cwd(tmpdir):
+            fake_local_fs_storage = FileSystemDataStorage()
+            fake_local_path_factory = WickerPathFactory(root_path=tmpdir)
+            with ColumnBytesFileWriter(
+                storage=fake_local_fs_storage,
+                s3_path_factory=fake_local_path_factory,
+                target_file_rowgroup_size=10,
+            ) as writer:
+                locs = [
+                    writer.add("np_arr", FAKE_NUMPY_CODEC.validate_and_encode_object(data["np_arr"]))  # type: ignore
+                    for data in FAKE_DATA
+                ]
+
+            arrow_metadata_table = pa.Table.from_pydict(
+                {"foo": [data["foo"] for data in FAKE_DATA], "np_arr": [loc.to_bytes() for loc in locs]}
+            )
+            metadata_table_path = os.path.join(
+                tmpdir, fake_local_path_factory._get_dataset_partition_path(FAKE_DATASET_PARTITION)
+            )
+            os.makedirs(os.path.dirname(metadata_table_path), exist_ok=True)
+            papq.write_table(arrow_metadata_table, metadata_table_path)
+
+            fake_local_fs_storage.put_object(
+                serialization.dumps(FAKE_SCHEMA).encode("utf-8"),
+                fake_local_path_factory._get_dataset_schema_path(FAKE_DATASET_ID),
+            )
+            yield fake_local_fs_storage, fake_local_path_factory, tmpdir
+
+    def test_filesystem_dataset(self):
+        with self._setup_storage() as (fake_local_storage, fake_local_path_factory, tmpdir):
+            with tempfile.TemporaryDirectory() as tmp_cache_dir:
+                pa_filesystem = pafs.LocalFileSystem()
+                ds = FileSystemDataset(
+                    FAKE_NAME,
+                    FAKE_PARTITION,
+                    FAKE_VERSION,
+                    pa_filesystem,
+                    fake_local_path_factory,
+                    fake_local_storage,
+                    columns_to_load=None,
+                    local_cache_path_prefix=tmp_cache_dir,
+                )
+                for i in range(len(FAKE_DATA)):
+                    retrieved = ds[i]
+                    reference = FAKE_DATA[i]
+                    self.assertEqual(retrieved["foo"], reference["foo"])
+                    np.testing.assert_array_equal(retrieved["np_arr"], reference["np_arr"])
+
+                # test that the dataset size in the tmpdir is the same as the starting dir
+                tmpdir_size = get_size(tmp_cache_dir)
+                expect_dir_size = get_size(os.path.join(tmpdir, "__COLUMN_CONCATENATED_FILES__"))
+                # test that all column files are copied over that are meant to be
+                assert tmpdir_size == expect_dir_size
 
 
 class TestS3Dataset(unittest.TestCase):
@@ -144,14 +216,12 @@ class TestS3Dataset(unittest.TestCase):
                 def Object(self, bucket: str, key: str) -> FakeResponse:
                     full_path = os.path.join("s3://", bucket, key)
                     data = fake_s3_storage.fetch_obj_s3(full_path)
-
                     return FakeResponse(content_length=len(data))
 
             def mock_resource_returner(_: Any):
                 return MockedS3Resource()
 
             with patch("wicker.core.datasets.boto3.resource", mock_resource_returner):
-
                 ds = S3Dataset(
                     FAKE_NAME,
                     FAKE_VERSION,

--- a/wicker/core/datasets.py
+++ b/wicker/core/datasets.py
@@ -11,10 +11,20 @@ import pyarrow  # type: ignore
 import pyarrow.fs as pafs  # type: ignore
 import pyarrow.parquet as papq  # type: ignore
 
-from wicker.core.column_files import ColumnBytesFileCache, ColumnBytesFileLocationV1
+from wicker.core.column_files import (
+    ColumnBytesFileCache,
+    ColumnBytesFileLocationV1,
+    ColumnBytesFileReader,
+)
 from wicker.core.config import get_config  # type: ignore
-from wicker.core.definitions import DatasetDefinition, DatasetID, DatasetPartition
-from wicker.core.storage import S3DataStorage, S3PathFactory
+from wicker.core.definitions import DatasetID, DatasetPartition
+from wicker.core.storage import (
+    AbstractDataStorage,
+    FileSystemDataStorage,
+    S3DataStorage,
+    S3PathFactory,
+    WickerPathFactory,
+)
 from wicker.schema import dataloading, serialization
 from wicker.schema.schema import DatasetSchema
 
@@ -125,17 +135,189 @@ class AbstractDataset(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def schema(self) -> DatasetSchema:
-        """Return the schema of the dataset."""
-        pass
-
-    @abc.abstractmethod
     def arrow_table(self) -> pyarrow.Table:
         """Return the pyarrow table with all the metadata fields and pointers of the dataset."""
         pass
 
+    @abc.abstractmethod
+    def schema(self) -> DatasetSchema:
+        """Return the schema of the dataset."""
+        pass
 
-class S3Dataset(AbstractDataset):
+
+class BaseDataset(AbstractDataset):
+    """Provides an implementation for part of the AbstractDataset interface for datasets whose items
+    and schema can be read from AbstractDataStorage concrete class."""
+
+    def __init__(
+        self,
+        dataset_name: str,
+        dataset_version: str,
+        dataset_partition_name: str,
+        pa_filesystem: pafs.FileSystem,
+        path_factory: WickerPathFactory,
+        storage: AbstractDataStorage,
+        columns_to_load: Optional[List[str]] = None,
+        filelock_timeout_seconds: int = FILE_LOCK_TIMEOUT_SECONDS,
+        local_cache_path_prefix: str = "",
+        treat_objects_as_bytes: bool = False,
+        filters=None,
+    ) -> None:
+        """Init for a BaseDataset.
+
+        :param dataset_name: name of the dataset
+        :param dataset_version: version of the dataset
+        :param dataset_partition_name: partition name
+        :param pa_filesystem: Pyarrow filesystem for reading the parquet files and tables.
+        :param path_factory: WickerPathFactory for pulling consistent paths.
+        :param storage: AbstractDataStorage for data access.
+        :param columns_to_load: list of columns to load, defaults to None which loads all columns
+        :param filelock_timeout_seconds: number of seconds after which to timeout on waiting for downloads,
+            defaults to FILE_LOCK_TIMEOUT_SECONDS
+        :param local_cache_path_prefix: Path to local cache path, if empty don't create cache
+        :param treat_objects_as_bytes: If set, don't try to decode ObjectFields and keep them as binary data.
+        :param filters: Only returns rows which match the filter. Defaults to None, i.e., returns all rows.
+        :type filters: pyarrow.compute.Expression, List[Tuple], or List[List[Tuple]], optional
+        .. seealso:: `filters in <https://arrow.apache.org/docs/python/generated/pyarrow.parquet.read_table.html>`__ # noqa
+        """
+        self._arrow_table: Optional[pyarrow.Table] = None  # Set by lazy initialization
+        self._columns_to_load = columns_to_load
+        self._dataset_id = DatasetID(name=dataset_name, version=dataset_version)
+        self._dataset_name = dataset_name
+        self._dataset_version = dataset_version
+        self._filelock_timeout_seconds = filelock_timeout_seconds
+        self._filters = filters
+        self._local_cache_path_prefix = local_cache_path_prefix
+        self._pa_filesystem = pa_filesystem
+        self._partition = DatasetPartition(dataset_id=self._dataset_id, partition=dataset_partition_name)
+        self._path_factory = path_factory
+        self._schema: Optional[DatasetSchema] = None  # Set by lazy initialization
+        self._storage = storage
+        self._treat_objects_as_bytes = treat_objects_as_bytes
+
+        # Create the column bytes reader that depends on the other init parameter values.
+        self._column_bytes_file_reader = self._build_column_bytes_reader()
+
+    def __getitem__(self, idx: int) -> Dict[str, Any]:
+        """Get data item at index within arrow table.
+
+        Pulls from either cache or data store the item in the dataset at index specified.
+
+        Args:
+            idx (int): idx in arrow table to grab data.
+
+        Returns:
+            Dict[str, Any]: Row of data defined through schema object.
+        """
+        tbl = self.arrow_table()
+        columns = self._columns_to_load if self._columns_to_load is not None else tbl.column_names
+        row = {col: tbl[col][idx].as_py() for col in columns}
+        schema = self.schema()
+        return dataloading.load_example(
+            self._column_bytes_file_reader.resolve_pointers(row, schema),
+            schema,
+        )
+
+    def __len__(self) -> int:
+        """Get length of arrow table inferring it is the same as the dataset.
+
+        Returns:
+            int: length of arrow table.
+        """
+        return len(self.arrow_table())
+
+    def _build_column_bytes_reader(self) -> ColumnBytesFileReader:
+        """Builder function to return a column bytes file reader."""
+        if self._local_cache_path_prefix:
+            # If caching column files from storage into the local filesystem, return a cache-enabled reader.
+            return ColumnBytesFileCache(
+                local_cache_path_prefix=self._local_cache_path_prefix,
+                filelock_timeout_seconds=self._filelock_timeout_seconds,
+                path_factory=self._path_factory,
+                storage=self._storage,
+                dataset_name=self._dataset_name,
+            )
+        return ColumnBytesFileReader(
+            dataset_name=self._dataset_name,
+            path_factory=self._path_factory,
+        )
+
+    def arrow_table(self) -> pyarrow.Table:
+        """Grab and load arrow table from expected path.
+
+        Returns:
+            pyarrow.Table: Arrow table object for the loaded dataset.
+        """
+        path = self._path_factory._get_dataset_partition_path(self._partition)
+        if not self._arrow_table:
+            self._arrow_table = papq.read_table(
+                path,
+                columns=self._columns_to_load,
+                filesystem=self._pa_filesystem,
+                filters=self._filters,
+            )
+        return self._arrow_table
+
+    def schema(self) -> DatasetSchema:
+        """Return the schema of the dataset."""
+        if self._schema is None:
+            schema_path = self._path_factory._get_dataset_schema_path(self._dataset_id)
+            local_path = self._storage.fetch_file(
+                schema_path, self._local_cache_path_prefix, timeout_seconds=self._filelock_timeout_seconds
+            )
+            with open(local_path, "rb") as f:
+                self._schema = serialization.loads(
+                    f.read().decode("utf-8"), treat_objects_as_bytes=self._treat_objects_as_bytes
+                )
+        return self._schema
+
+
+class FileSystemDataset(BaseDataset):
+    """Implementation of a Map-based dataset on local file system or mounted drive"""
+
+    def __init__(
+        self,
+        dataset_name: str,
+        dataset_version: str,
+        dataset_partition_name: str,
+        pa_filesystem: pafs.LocalFileSystem,
+        path_factory: WickerPathFactory,
+        storage: FileSystemDataStorage,
+        columns_to_load: Optional[List[str]] = None,
+        local_cache_path_prefix: str = "",
+        treat_objects_as_bytes: bool = False,
+        filters=None,
+    ):
+        """Initializes a FileSystemDataset.
+
+        :param dataset_name: name of the dataset
+        :param dataset_version: version of the dataset
+        :param dataset_partition_name: partition name
+        :param pa_filesystem: Pyarrow local filesystem for reading the parquet files and tables.
+        :param path_factory: WickerPathFactory for pulling consistent paths.
+        :param storage: FileSystemDataStorage object for pulling files from filesystem
+        :param columns_to_load: list of columns to load, defaults to None which loads all columns
+        :param local_cache_path_prefix: Path to local cache path, if empty don't create cache
+        :param treat_objects_as_bytes: If set, don't try to decode ObjectFields and keep them as binary data.
+        :param filters: Only returns rows which match the filter. Defaults to None, i.e., returns all rows.
+        :type filters: pyarrow.compute.Expression, List[Tuple], or List[List[Tuple]], optional
+        .. seealso:: `filters in <https://arrow.apache.org/docs/python/generated/pyarrow.parquet.read_table.html>`__ # noqa
+        """
+        super().__init__(
+            dataset_name,
+            dataset_version,
+            dataset_partition_name,
+            pa_filesystem,
+            path_factory,
+            storage,
+            columns_to_load=columns_to_load,
+            local_cache_path_prefix=local_cache_path_prefix,
+            treat_objects_as_bytes=treat_objects_as_bytes,
+            filters=filters,
+        )
+
+
+class S3Dataset(BaseDataset):
     """Implementation for a Map-based dataset"""
 
     def __init__(
@@ -157,8 +339,11 @@ class S3Dataset(AbstractDataset):
         :param dataset_name: name of the dataset
         :param dataset_version: version of the dataset
         :param dataset_partition_name: partition name
+        :param local_cache_path_prefix: Path to local cache path, if empty don't create cache
         :param columns_to_load: list of columns to load, defaults to None which loads all columns
-        :param data_service: S3DataService instance to use, defaults to None which uses default initializations
+        :param storage: S3DataStorage object for pulling files from cloud storage
+        :param s3_path_factory: S3PathFactory for pulling consistent paths.
+        :param pa_filesystem: Pyarrow filesystem for reading the parquet files and tables.
         :param filelock_timeout_seconds: number of seconds after which to timeout on waiting for downloads,
             defaults to FILE_LOCK_TIMEOUT_SECONDS
         :param treat_objects_as_bytes: If set, don't try to decode ObjectFields and keep them as binary data
@@ -166,46 +351,25 @@ class S3Dataset(AbstractDataset):
         :type filters: pyarrow.compute.Expression, List[Tuple], or List[List[Tuple]], optional
         .. seealso:: `filters in <https://arrow.apache.org/docs/python/generated/pyarrow.parquet.read_table.html>`__ # noqa
         """
-        super().__init__()
-        self._columns_to_load: Optional[List[str]] = columns_to_load
-        self._treat_objects_as_bytes = treat_objects_as_bytes
-        self._schema: Optional[DatasetSchema] = None
-        self._arrow_table: Optional[pyarrow.Table] = None
-
-        self._local_cache_path_prefix = local_cache_path_prefix
-        self._filelock_timeout_seconds = filelock_timeout_seconds
-        self._storage = storage if storage is not None else S3DataStorage()
-        self._s3_path_factory = s3_path_factory if s3_path_factory is not None else S3PathFactory()
-        self._column_bytes_file_cache = ColumnBytesFileCache(
-            local_cache_path_prefix=local_cache_path_prefix,
-            filelock_timeout_seconds=filelock_timeout_seconds,
-            path_factory=self._s3_path_factory,
-            storage=self._storage,
-            dataset_name=dataset_name,
-        )
-        self._pa_filesystem = (
+        s3_path_factory = s3_path_factory if s3_path_factory is not None else S3PathFactory()
+        pa_filesystem = (
             pafs.S3FileSystem(region=get_config().aws_s3_config.region) if pa_filesystem is None else pa_filesystem
         )
-
-        self._dataset_id = DatasetID(name=dataset_name, version=dataset_version)
-        self._partition = DatasetPartition(dataset_id=self._dataset_id, partition=dataset_partition_name)
-        self._dataset_definition = DatasetDefinition(
-            self._dataset_id,
-            schema=self.schema(),
+        super().__init__(
+            dataset_name,
+            dataset_version,
+            dataset_partition_name,
+            pa_filesystem,
+            s3_path_factory,
+            storage,
+            columns_to_load=columns_to_load,
+            filelock_timeout_seconds=filelock_timeout_seconds,
+            local_cache_path_prefix=local_cache_path_prefix,
+            treat_objects_as_bytes=treat_objects_as_bytes,
+            filters=filters,
         )
+        self._s3_path_factory = s3_path_factory
         self.filters = filters
-
-    def schema(self) -> DatasetSchema:
-        if self._schema is None:
-            schema_path = self._s3_path_factory.get_dataset_schema_path(self._dataset_id)
-            local_path = self._storage.fetch_file(
-                schema_path, self._local_cache_path_prefix, timeout_seconds=self._filelock_timeout_seconds
-            )
-            with open(local_path, "rb") as f:
-                self._schema = serialization.loads(
-                    f.read().decode("utf-8"), treat_objects_as_bytes=self._treat_objects_as_bytes
-                )
-        return self._schema
 
     def arrow_table(self) -> pyarrow.Table:
         path = self._s3_path_factory.get_dataset_partition_path(self._partition, s3_prefix=False)
@@ -214,18 +378,6 @@ class S3Dataset(AbstractDataset):
                 path, columns=self._columns_to_load, filesystem=self._pa_filesystem, filters=self.filters
             )
         return self._arrow_table
-
-    def __len__(self) -> int:
-        return len(self.arrow_table())
-
-    def __getitem__(self, idx: int) -> Dict[str, Any]:
-        tbl = self.arrow_table()
-        columns = self._columns_to_load if self._columns_to_load is not None else tbl.column_names
-        row = {col: tbl[col][idx].as_py() for col in columns}
-        return dataloading.load_example(
-            self._column_bytes_file_cache.resolve_pointers(row, self.schema()),
-            self.schema(),
-        )
 
     def _get_parquet_dir_size(self) -> int:
         """Get the parquet path and find all the files within, count their bytes


### PR DESCRIPTION
Incorporate the changes from the reviews for https://github.com/woven-planet/wicker/pull/57. In this PR, we leave `AbstractDataset` alone so that it remains a pure interface. As suggested in Zhenyu's review, we create the `BaseDataset` class as a concrete implementation of `AbstractDataset` that is orthogonal to any filesytem or bucket-specific assumptions (it will rely on the `storage` and column file reader instances for this logic).

The `S3Dataset` class is updated so that it is a subclass of `BaseDataset`. We still create the new `FileSystemDataset` class, but it only exists so that its constructor arguments can be constrained to be compatible with local storage (e.g. the `storage` argument must have the type `FileSystemDataStorage` and the Arrow filesystem has to be a `LocalFileSystem`). It could be ok to remove this class though.

Testing:
- Unit tests added to cover the new `FileSystemDataset` class and its new behavior to support local storage (together with `BaseDataset`).
- Running test training jobs is in progress; they will be linked here.

Note: One thing Zhenyu proposed in his review of Isaak's PR is to change the user experience so that they use a factory to return instances of `AbstractDataset`. We want to leave this new user experience up to the platform team. However, the new factory methods should work well with the changes in this PR!